### PR TITLE
chore: Add byte-compiled files to the .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
+# Secrets
 secrets.py
 hochwasserwarnapp-4b01ebd06065.json
 warnMeApi/express-api/sensor_data.db
+
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class


### PR DESCRIPTION
Byte-compiled python files are usually ignored in Git-Repositories, see https://github.com/github/gitignore/blob/main/Python.gitignore